### PR TITLE
NPE occurs when Dart SDK location changes on the preference page. #86

### DIFF
--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
@@ -25,10 +25,9 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.IPersistentPreferenceStore;
-import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
@@ -82,18 +81,11 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 		boolean ok = super.performOk();
 		boolean result = MessageDialog.openQuestion(null, Messages.Preference_RestartRequired_Title,
 				Messages.Preference_RestartRequired_Message);
-
 		if (result) {
-			try {
-				// Manually save the preference store since it doesn't seem to happen when
-				// restarting the IDE in the following step.
-				save();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-			PlatformUI.getWorkbench().restart(true);
+			Display.getDefault().asyncExec(() -> {
+				PlatformUI.getWorkbench().restart();
+			});
 		}
-
 		return ok;
 	}
 
@@ -156,17 +148,5 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 			setValid(dartSDKLocationEditor.doCheckState());
 		}
 		super.propertyChange(event);
-	}
-
-	/**
-	 * Saves the underlying {@link IPersistentPreferenceStore}.
-	 * 
-	 * @throws IOException
-	 */
-	private void save() throws IOException {
-		IPreferenceStore store = getPreferenceStore();
-		if (store instanceof IPersistentPreferenceStore) {
-			((IPersistentPreferenceStore) store).save();
-		}
 	}
 }

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
@@ -83,7 +83,7 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 				Messages.Preference_RestartRequired_Message);
 		if (result) {
 			Display.getDefault().asyncExec(() -> {
-				PlatformUI.getWorkbench().restart();
+				PlatformUI.getWorkbench().restart(true);
 			});
 		}
 		return ok;

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
@@ -25,6 +25,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IPersistentPreferenceStore;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -81,7 +83,16 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 		boolean ok = super.performOk();
 		boolean result = MessageDialog.openQuestion(null, Messages.Preference_RestartRequired_Title,
 				Messages.Preference_RestartRequired_Message);
+
 		if (result) {
+			try {
+				// Manually save the preference store since it doesn't seem to happen when
+				// restarting the IDE in the following step.
+				save();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		
 			Display.getDefault().asyncExec(() -> {
 				PlatformUI.getWorkbench().restart(true);
 			});
@@ -148,5 +159,17 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 			setValid(dartSDKLocationEditor.doCheckState());
 		}
 		super.propertyChange(event);
+	}
+
+	/**
+	 * Saves the underlying {@link IPersistentPreferenceStore}.
+	 * 
+	 * @throws IOException
+	 */
+	private void save() throws IOException {
+		IPreferenceStore store = getPreferenceStore();
+		if (store.needsSaving() && store instanceof IPersistentPreferenceStore) {
+			((IPersistentPreferenceStore) store).save();
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Lakshminarayana Nekkanti <narayana.nekkanti@gmail.com>

@jonas-jonas  Can you cross check?

`		boolean ok = super.performOk();
`
will saves preferences. I think  calling save method is not required 

restart  operation should be in an asynchronous thread