### PR TITLE
Add check for valid Dart SDK to preference page

### DIFF
--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
@@ -76,6 +76,7 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 			setValid(false);
 			return false;
 		}
+		System.err.println(path);
 
 		dartSDKLocationEditor.setStringValue(path.toAbsolutePath().toString());
 
@@ -109,29 +110,13 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 		if (dartSDKLocationEditor.isValid()) {
 			Path path = null;
 			try {
-				path = Paths.get(location);
-				path = path.toRealPath();
+				path = Paths.get(location + "/bin/dart"); //$NON-NLS-1$
+				// Since we append /bin/dart to resolve the symbolic links, we need to get 2
+				// levels up here.
+				path = path.toRealPath().toAbsolutePath().getParent().getParent();
 			} catch (IOException e) {
 				LOG.error("Couldn't follow symlink", e); //$NON-NLS-1$
 			}
-
-			if (path == null) {
-				return null;
-			}
-			
-			// Sometimes users put in the path to the Dart executable directly, instead of
-			// the directory of the installation. Here we use the parent first (which should
-			// be /bin)
-			if (path.endsWith("dart")) { //$NON-NLS-1$
-				path = path.getParent();
-			}
-			// Sometimes users put in the path when it still contains the /bin portion.
-			// Since we only want the root of the Dart SDK installation we use the parent if
-			// /bin was supplied.
-			if (path.endsWith("bin")) {//$NON-NLS-1$
-				path = path.getParent();
-			}
-
 			return path;
 		} else {
 			return null;

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
@@ -14,7 +14,6 @@
 package org.eclipse.dartboard.preference;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -77,7 +76,6 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 			setValid(false);
 			return false;
 		}
-		System.err.println(path);
 
 		dartSDKLocationEditor.setStringValue(path.toAbsolutePath().toString());
 

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartPreferencePage.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.dartboard.preference;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.dartboard.Constants;
 import org.eclipse.dartboard.Messages;
@@ -106,10 +108,12 @@ public class DartPreferencePage extends FieldEditorPreferencePage implements IWo
 	 * @return
 	 */
 	private Path getPath(String location) {
+
 		if (dartSDKLocationEditor.isValid()) {
 			Path path = null;
 			try {
-				path = Paths.get(location + "/bin/dart"); //$NON-NLS-1$
+				boolean isWindows = Platform.OS_WIN32.equals(Platform.getOS());
+				path = Paths.get(location + "bin" + File.separator + (isWindows ? "dart.exe" : "dart")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				// Since we append /bin/dart to resolve the symbolic links, we need to get 2
 				// levels up here.
 				path = path.toRealPath().toAbsolutePath().getParent().getParent();

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -89,7 +89,7 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 
 		String[] commands;
 		if (isWindows) {
-			commands = new String[] { "cmd", executablePath + ".exe --version" };
+			commands = new String[] { "cmd", "/c", executablePath + ".exe --version" };
 		} else {
 			commands = new String[] { "/bin/bash", "-c", executablePath + " --version" };
 		}

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -12,8 +12,12 @@ import org.eclipse.dartboard.Messages;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DartSDKLocationFieldEditor.class);
 
 	public DartSDKLocationFieldEditor(String preferencesKey, String label, Composite parent) {
 		super(preferencesKey, label, parent);
@@ -34,15 +38,32 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 	@SuppressWarnings("nls")
 	private boolean isValidDartSDK(String location) {
 		Path path = Paths.get(location);
+		// If the entered file doesn't exist, there is no need to run it
+		// Similarly if the file is not a directory
 		if (!Files.exists(path)) {
 			return false;
+		}
+		try {
+			path = path.toRealPath();
+		} catch (IOException e1) {
+			LOG.error("Couldn't follow symlink", e1);
+			return false;
+		}
+
+		String executablePath = null;
+		if (path.endsWith("bin/dart")) {
+			executablePath = path.toAbsolutePath().toString();
+		} else if (path.endsWith("bin")) {
+			executablePath = path.toAbsolutePath().toString() + "/dart";
+		} else {
+			executablePath = path.toAbsolutePath().toString() + "/bin/dart";
 		}
 
 		String[] commands;
 		if (Platform.OS_WIN32.equals(Platform.getOS())) {
-			commands = new String[] { "cmd", "/c", location + "/bin/dart --version" };
+			commands = new String[] { "cmd", "/c", executablePath + " --version" };
 		} else {
-			commands = new String[] { "/bin/bash", "-c", location + "/bin/dart --version" };
+			commands = new String[] { "/bin/bash", "-c", executablePath + " --version" };
 		}
 
 		ProcessBuilder processBuilder = new ProcessBuilder(commands);

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -1,7 +1,13 @@
 package org.eclipse.dartboard.preference;
 
-import java.io.File;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.dartboard.Messages;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.swt.events.ModifyListener;
@@ -17,13 +23,40 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 	@Override
 	protected boolean doCheckState() {
 		String location = getTextControl().getText();
-		File file = new File(location);
-		boolean isValid = file.exists();
+		boolean isValid = isValidDartSDK(location);
 		if (!isValid) {
 			setErrorMessage(Messages.Preference_SDKNotFound_Message);
 			showErrorMessage();
 		}
 		return isValid;
+	}
+
+	@SuppressWarnings("nls")
+	private boolean isValidDartSDK(String location) {
+		Path path = Paths.get(location);
+		if (!Files.exists(path)) {
+			return false;
+		}
+
+		String[] commands;
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			commands = new String[] { "cmd", "/c", location + "/bin/dart --version" };
+		} else {
+			commands = new String[] { "/bin/bash", "-c", location + "/bin/dart --version" };
+		}
+
+		ProcessBuilder processBuilder = new ProcessBuilder(commands);
+
+		processBuilder.redirectErrorStream(true);
+		String version = null;
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(processBuilder.start().getInputStream()))) {
+			version = reader.readLine();
+		} catch (IOException e) {
+			return false;
+		}
+
+		return version.startsWith("Dart VM version");
 	}
 
 	protected void addModifyListener(ModifyListener listener) {

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -82,12 +82,13 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 			return false;
 		}
 
+		boolean isWindows = Platform.OS_WIN32.equals(Platform.getOS());
+
 		String executablePath = path.toAbsolutePath().toString();
 
-		System.out.println(executablePath);
 		String[] commands;
-		if (Platform.OS_WIN32.equals(Platform.getOS())) {
-			commands = new String[] { "cmd", executablePath + " --version" };
+		if (isWindows) {
+			commands = new String[] { "cmd", executablePath + ".exe --version" };
 		} else {
 			commands = new String[] { "/bin/bash", "-c", executablePath + " --version" };
 		}

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -61,12 +61,13 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 	 */
 	@SuppressWarnings("nls")
 	private boolean isValidDartSDK(String location) {
+		boolean isWindows = Platform.OS_WIN32.equals(Platform.getOS());
 		Path path = null;
 		// On Windows if a certain wrong combination of characters are entered a
 		// InvalidPathException is thrown. In that case we can assume that the location
 		// entered is not a valid Dart SDK directory either.
 		try {
-			path = Paths.get(location).resolve("bin" + File.separator + "dart");
+			path = Paths.get(location).resolve("bin" + File.separator + (isWindows ? "dart.exe" : "dart"));
 		} catch (InvalidPathException e) {
 			return false;
 		}
@@ -83,7 +84,6 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 			return false;
 		}
 
-		boolean isWindows = Platform.OS_WIN32.equals(Platform.getOS());
 
 		String executablePath = path.toAbsolutePath().toString();
 

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -89,7 +89,7 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 
 		String[] commands;
 		if (isWindows) {
-			commands = new String[] { "cmd", "/c", executablePath + " --version" };
+			commands = new String[] { "cmd", "/c", executablePath, "--version" };
 		} else {
 			commands = new String[] { "/bin/bash", "-c", executablePath + " --version" };
 		}

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -89,7 +89,7 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 
 		String[] commands;
 		if (isWindows) {
-			commands = new String[] { "cmd", "/c", executablePath + ".exe --version" };
+			commands = new String[] { "cmd", "/c", executablePath + " --version" };
 		} else {
 			commands = new String[] { "/bin/bash", "-c", executablePath + " --version" };
 		}

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preference/DartSDKLocationFieldEditor.java
@@ -1,6 +1,7 @@
 package org.eclipse.dartboard.preference;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
@@ -65,7 +66,7 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 		// InvalidPathException is thrown. In that case we can assume that the location
 		// entered is not a valid Dart SDK directory either.
 		try {
-			path = Paths.get(location).resolve("bin/dart");
+			path = Paths.get(location).resolve("bin" + File.separator + "dart");
 		} catch (InvalidPathException e) {
 			return false;
 		}


### PR DESCRIPTION
This patch adds a check to the preference page as-you-type validation.

One thing to answer: 

Is there a better way to spawn processes? In this patch we would spawn a new process with `$ dart --version` for every file/directory entered. Any suggestions?