### PR TITLE
Streamline import of Dart projects

### DIFF
--- a/org.eclipse.dartboard/plugin.xml
+++ b/org.eclipse.dartboard/plugin.xml
@@ -248,4 +248,25 @@
              class="org.eclipse.dartboard.ListenerService">
        </startup>
     </extension>
+    <extension
+          point="org.eclipse.ui.importWizards">
+       <wizard
+             category="org.eclipse.dartboard.import.category"
+             class="org.eclipse.ui.internal.wizards.datatransfer.SmartImportWizard"
+             icon="icons/dart.png"
+             id="org.eclipse.dartboard.import.wizard"
+             name="Dart Project">
+       </wizard>
+       <category
+             id="org.eclipse.dartboard.import.category"
+             name="Dart">
+       </category>
+    </extension>
+    <extension
+          point="org.eclipse.ui.ide.projectConfigurators">
+       <projectConfigurator
+             class="org.eclipse.dartboard.project.DartProjectConfigurator"
+             label="Dart Project">
+       </projectConfigurator>
+    </extension>
 </plugin>

--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/project/DartProjectConfigurator.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/project/DartProjectConfigurator.java
@@ -1,0 +1,69 @@
+package org.eclipse.dartboard.project;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.dartboard.Constants;
+import org.eclipse.ui.wizards.datatransfer.ProjectConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DartProjectConfigurator implements ProjectConfigurator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DartProjectConfigurator.class);
+
+	@Override
+	public Set<File> findConfigurableLocations(File root, IProgressMonitor monitor) {
+		Set<File> files = new HashSet<>();
+
+		try {
+			Files.walkFileTree(root.toPath(), new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					if (file.endsWith(Constants.PUBSPEC)) {
+						files.add(file.toFile().getParentFile());
+					}
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			LOG.error("Couldn't walk children directories", e); //$NON-NLS-1$
+		}
+		return files;
+	}
+
+	@Override
+	public boolean shouldBeAnEclipseProject(IContainer container, IProgressMonitor monitor) {
+		return true;
+	}
+
+	@Override
+	public Set<IFolder> getFoldersToIgnore(IProject project, IProgressMonitor monitor) {
+		// Currently there are no to ignore in Dart projects
+		return null;
+	}
+
+	@Override
+	public boolean canConfigure(IProject project, Set<IPath> ignoredPaths, IProgressMonitor monitor) {
+		// Do nothing, as everything is handled in ListenerService
+		return false;
+	}
+
+	@Override
+	public void configure(IProject project, Set<IPath> ignoredPaths, IProgressMonitor monitor) {
+		// Do nothing, as everything is handled in ListenerService
+	}
+
+}


### PR DESCRIPTION
With this PR users get a better experience when importing Dart projects.
I added an `ImportWizard` extension, that just delegates to the `org.eclipse.ui.internal.wizards.datatransfer.SmartImportWizard`. As we don't need to do anything on import and I'd just like a "Dart Project" import shortcut this is the best way to accomplish both I found.

There is also a ProjectConfigurator that traverses the children of any selected directory and searches for folders that contain a `pubspec.yaml` file. 

See 
![streamline-import](https://user-images.githubusercontent.com/5540255/62233728-72f57c80-b3c9-11e9-9008-a766eba7b5d0.gif)

Closes #102 