### PR TITLE
Need to provide icon for dart content type

### DIFF
--- a/org.eclipse.dartboard/plugin.xml
+++ b/org.eclipse.dartboard/plugin.xml
@@ -263,4 +263,11 @@
              label="Dart Project">
        </projectConfigurator>
     </extension>
+    <extension
+          point="org.eclipse.ui.genericeditor.icons">
+       <icon
+             contentType="org.eclipse.dartboard"
+             icon="icons/dart_file.png">
+       </icon>
+    </extension>
 </plugin>


### PR DESCRIPTION
Extension will only be used in 2019-09, older releases should ignore it.

Signed-off-by: Lars Vogel <Lars.Vogel@vogella.com>