### PR TITLE
Add dependency on Wild Web Developer

### DIFF
--- a/org.eclipse.dartboard.feature/feature.xml
+++ b/org.eclipse.dartboard.feature/feature.xml
@@ -32,6 +32,10 @@
       [Enter License Description here.]
    </license>
 
+   <includes
+         id="org.eclipse.wildwebdeveloper.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.dartboard"
          download-size="0"


### PR DESCRIPTION
Adds wild web developer as included feature for the dart feature. p2
installation should therefore automatically install wwd if dart is
installed.

Fixes: https://github.com/eclipse/dartboard/issues/108

Signed-off-by: Lars Vogel <Lars.Vogel@vogella.com>