### PR TITLE
This commit fixes #179

### DIFF
--- a/org.eclipse.dartboard/src/org/eclipse/dartboard/preferences/DartSDKLocationFieldEditor.java
+++ b/org.eclipse.dartboard/src/org/eclipse/dartboard/preferences/DartSDKLocationFieldEditor.java
@@ -129,11 +129,12 @@ public class DartSDKLocationFieldEditor extends DirectoryFieldEditor {
 		try (BufferedReader reader = new BufferedReader(
 				new InputStreamReader(processBuilder.start().getInputStream()))) {
 			version = reader.readLine();
+			version = version.toLowerCase();
 		} catch (IOException e) {
 			return false;
 		}
 
-		return version.startsWith("Dart VM version");
+		return (version.contains(new String("dart")) && version.contains(new String("version")));
 	}
 
 	protected void addModifyListener(ModifyListener listener) {


### PR DESCRIPTION
Correct wrong string compare for Dart SDK location validation in Eclipse
preference view.

Signed-off-by: Bryan Claude Alain BERTHOU <bryan25.berthou@laposte.net>